### PR TITLE
Feature/find all reflexive

### DIFF
--- a/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
@@ -5,12 +5,15 @@ import net.smartcosmos.dao.relationships.RelationshipDao;
 import net.smartcosmos.dao.relationships.domain.RelationshipEntity;
 import net.smartcosmos.dao.relationships.repository.RelationshipRepository;
 import net.smartcosmos.dao.relationships.util.SearchSpecifications;
-import net.smartcosmos.dto.relationships.RelationshipUpsert;
 import net.smartcosmos.dto.relationships.RelationshipResponse;
+import net.smartcosmos.dto.relationships.RelationshipUpsert;
 import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.domain.Specifications;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.TransactionException;
 
@@ -185,7 +188,22 @@ public class RelationshipPersistenceService implements RelationshipDao {
 
     @Override
     public List<RelationshipResponse> findAllReflexive(String accountUrn, String entityReferenceType, String referenceUrn) {
-        return null;
+
+        Specification<RelationshipEntity> accountUrnSpecification = null;
+        if (StringUtils.isNotBlank(accountUrn)) {
+            UUID accountUuid = UuidUtil.getUuidFromAccountUrn(accountUrn);
+            accountUrnSpecification = searchSpecifications.matchUuid(accountUuid, "accountId");
+        }
+
+        Iterable<RelationshipEntity> returnedValues = relationshipRepository.findAll(Specifications.where(accountUrnSpecification));
+
+        // TODO: Add Specification for reflexive query
+
+        List<RelationshipResponse> convertedList = new ArrayList<>();
+        for (RelationshipEntity entity: returnedValues) {
+            convertedList.add(conversionService.convert(entity, RelationshipResponse.class));
+        }
+        return convertedList;
     }
 
 

--- a/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
@@ -184,41 +184,65 @@ public class RelationshipPersistenceService implements RelationshipDao {
     }
 
     @Override
+    public List<RelationshipResponse> findAll(String accountUrn, String entityReferenceType, String referenceUrn, Boolean checkReciprocal) {
+
+        List<RelationshipResponse> responseList = new ArrayList<>();
+
+        if (checkReciprocal) {
+            UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+
+            try {
+                List<RelationshipEntity> entityList = relationshipRepository.findByAccountIdAndEntityReferenceTypeAndReferenceId(
+                    accountId,
+                    entityReferenceType,
+                    UuidUtil.getUuidFromUrn(referenceUrn));
+
+                return entityList.stream()
+                    .map(o -> convertAndIncludeReciprocalFlag(accountId, o))
+                    .collect(Collectors.toList());
+            } catch (IllegalArgumentException e) {
+                // empty list will be returned anyway
+                log.warn("Illegal URN submitted by account %s: reference URN %s", accountUrn, referenceUrn);
+            }
+        } else {
+            responseList = findAllReflexive(accountUrn, entityReferenceType, referenceUrn);
+        }
+
+        return responseList;
+    }
+
+    @Override
     public List<RelationshipResponse> findAllReflexive(String accountUrn, String entityReferenceType, String referenceUrn) {
 
         UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
 
-        List<RelationshipResponse> responseList = new ArrayList<>();
+        List<RelationshipResponse> resultList = new ArrayList<>();
         try {
-            // find all
-            List<RelationshipEntity> allList = relationshipRepository.findByAccountIdAndEntityReferenceTypeAndReferenceId(
+            List<RelationshipEntity> entityList = relationshipRepository.findByAccountIdAndEntityReferenceTypeAndReferenceId(
                 accountId,
                 entityReferenceType,
                 UuidUtil.getUuidFromUrn(referenceUrn));
-    
-            for (RelationshipEntity entity : allList) {
-    
-                RelationshipResponse response = conversionService.convert(entity, RelationshipResponse.class);
-                
-                // find specific reciprocal
-                Optional<RelationshipEntity> reciprocal = relationshipRepository.findByAccountIdAndEntityReferenceTypeAndReferenceIdAndTypeAndRelatedEntityReferenceTypeAndRelatedReferenceId(
-                    accountId,
-                    entity.getRelatedEntityReferenceType(),
-                    entity.getRelatedReferenceId(),
-                    entity.getType(),
-                    entity.getEntityReferenceType(),
-                    entity.getReferenceId());
-    
-                response.setReciprocal(reciprocal.isPresent());
-                
-                responseList.add(response);
+
+            for (RelationshipEntity entity : entityList) {
+                Optional<RelationshipEntity> reciprocal = findReciprocalRelationshipEntity(accountId, entity);
+                if (reciprocal.isPresent()) {
+                    resultList.add(conversionService.convert(entity, RelationshipResponse.class));
+                    resultList.add(conversionService.convert(reciprocal.get(), RelationshipResponse.class));
+                }
             }
         } catch (IllegalArgumentException e) {
             // empty will be returned anyway
             log.warn("Illegal URN submitted by account %s: reference URN %s", accountUrn, referenceUrn);
         }
 
-        return responseList;
+        return resultList;
+    }
+
+    private RelationshipResponse convertAndIncludeReciprocalFlag(UUID accountId, RelationshipEntity entity) {
+        RelationshipResponse response = conversionService.convert(entity, RelationshipResponse.class);
+        response.setReciprocal(findReciprocalRelationshipEntity(accountId, entity).isPresent());
+
+        return response;
     }
 
 
@@ -255,6 +279,16 @@ public class RelationshipPersistenceService implements RelationshipDao {
             UuidUtil.getUuidFromUrn(upsertRelationship.getRelatedReferenceUrn()));
 
         return (existingEntity.isPresent() ? existingEntity.get().getId() : null);
+    }
+
+    private Optional<RelationshipEntity> findReciprocalRelationshipEntity(UUID accountId, RelationshipEntity entity) {
+        return relationshipRepository.findByAccountIdAndEntityReferenceTypeAndReferenceIdAndTypeAndRelatedEntityReferenceTypeAndRelatedReferenceId(
+            accountId,
+            entity.getRelatedEntityReferenceType(),
+            entity.getRelatedReferenceId(),
+            entity.getType(),
+            entity.getEntityReferenceType(),
+            entity.getReferenceId());
     }
 
     private List<RelationshipResponse> getResponseList(List<RelationshipEntity> entityList) {

--- a/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceService.java
@@ -8,6 +8,7 @@ import net.smartcosmos.dao.relationships.util.SearchSpecifications;
 import net.smartcosmos.dto.relationships.RelationshipResponse;
 import net.smartcosmos.dto.relationships.RelationshipUpsert;
 import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.convert.ConversionService;
@@ -204,7 +205,7 @@ public class RelationshipPersistenceService implements RelationshipDao {
 
         List<RelationshipResponse> responseList = new ArrayList<>();
 
-        if (checkReciprocal) {
+        if (BooleanUtils.isTrue(checkReciprocal)) {
             UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
 
             try {

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -317,5 +318,69 @@ public class RelationshipPersistanceServiceTest {
         assertEquals(TEST_REFERENCE_TYPE, responseList.get(0).getRelatedEntityReferenceType());
         assertEquals(TEST_RELATED_ENTITY, responseList.get(0).getRelatedReferenceUrn());
         assertEquals(TEST_MONIKER, responseList.get(0).getMoniker());
+    }
+
+    @Test
+    public void testFindAllReflexive() {
+        final String ENTITY_URN_A = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+        final String ENTITY_URN_B = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+
+        final String REFERENCE_TYPE = "Thing";
+        final String RELATIONSHIP_TYPE_REFLEXIVE = "Reflexive";
+        final String RELATIONSHIP_TYPE_NON_REFLEXIVE_A = "Not Reflexive";
+        final String RELATIONSHIP_TYPE_NON_REFLEXIVE_B = "Not Reflexive as well";
+
+        RelationshipUpsert reflexiveEntity1 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_A)
+            .type(RELATIONSHIP_TYPE_REFLEXIVE)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_B)
+            .build();
+        final String reflexiveUrn1 = relationshipPersistenceService.upsert(accountUrn, reflexiveEntity1).getUrn();
+
+        RelationshipUpsert reflexiveEntity2 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_B)
+            .type(RELATIONSHIP_TYPE_REFLEXIVE)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_A)
+            .build();
+        final String reflexiveUrn2 = relationshipPersistenceService.upsert(accountUrn, reflexiveEntity2).getUrn();
+
+        RelationshipUpsert nonReflexiveEntity1 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_A)
+            .type(RELATIONSHIP_TYPE_NON_REFLEXIVE_A)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_B)
+            .build();
+        final String nonReflexiveUrn1 = relationshipPersistenceService.upsert(accountUrn, nonReflexiveEntity1).getUrn();
+
+        RelationshipUpsert nonReflexiveEntity2 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_B)
+            .type(RELATIONSHIP_TYPE_NON_REFLEXIVE_B)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_A)
+            .build();
+        final String nonReflexiveUrn2 = relationshipPersistenceService.upsert(accountUrn, nonReflexiveEntity2).getUrn();
+
+        List<RelationshipResponse> responseList = relationshipPersistenceService.findAllReflexive(accountUrn, REFERENCE_TYPE, ENTITY_URN_A);
+
+        assertFalse(responseList.isEmpty());
+        assertEquals(2, responseList.size());
+        assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(0).getType());
+        assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(1).getType());
+
+        List<UUID> uuidList = responseList.stream()
+            .map(o -> UuidUtil.getUuidFromUrn(o.getUrn()))
+            .collect(Collectors.toList());
+
+        assertTrue(uuidList.contains(reflexiveUrn1));
+        assertTrue(uuidList.contains(reflexiveUrn2));
+
+        assertFalse(uuidList.contains(nonReflexiveUrn1));
+        assertFalse(uuidList.contains(nonReflexiveUrn2));
     }
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
@@ -373,14 +373,14 @@ public class RelationshipPersistanceServiceTest {
         assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(0).getType());
         assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(1).getType());
 
-        List<UUID> uuidList = responseList.stream()
-            .map(o -> UuidUtil.getUuidFromUrn(o.getUrn()))
+        List<String> urnList = responseList.stream()
+            .map(o -> o.getUrn())
             .collect(Collectors.toList());
 
-        assertTrue(uuidList.contains(reflexiveUrn1));
-        assertTrue(uuidList.contains(reflexiveUrn2));
+        assertTrue(urnList.contains(reflexiveUrn1));
+        assertTrue(urnList.contains(reflexiveUrn2));
 
-        assertFalse(uuidList.contains(nonReflexiveUrn1));
-        assertFalse(uuidList.contains(nonReflexiveUrn2));
+        assertFalse(urnList.contains(nonReflexiveUrn1));
+        assertFalse(urnList.contains(nonReflexiveUrn2));
     }
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
@@ -23,11 +23,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Collectors;
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -321,7 +317,7 @@ public class RelationshipPersistanceServiceTest {
     }
 
     @Test
-    public void testFindAllReflexive() {
+    public void testFindAllCheckReciprocal() {
         final String ENTITY_URN_A = "urn:uuid:" + UuidUtil.getNewUuidAsString();
         final String ENTITY_URN_B = "urn:uuid:" + UuidUtil.getNewUuidAsString();
 
@@ -366,34 +362,24 @@ public class RelationshipPersistanceServiceTest {
             .build();
         final String nonReflexiveUrn2 = relationshipPersistenceService.upsert(accountUrn, nonReflexiveEntity2).getUrn();
 
-        List<RelationshipResponse> responseList = relationshipPersistenceService.findAllReflexive(accountUrn, REFERENCE_TYPE, ENTITY_URN_A);
+        List<RelationshipResponse> responseList = relationshipPersistenceService.findAll(accountUrn, REFERENCE_TYPE, ENTITY_URN_A, true);
 
         assertFalse(responseList.isEmpty());
-        assertEquals(4, responseList.size());
-        
-        List<String> reflexiveList = new ArrayList<>();
-        List<String> nonReflexiveList = new ArrayList<>();
-        
+        assertEquals(2, responseList.size());
+
         for (RelationshipResponse response : responseList) {
-            
+
             assertNotNull(response.getReciprocal());
             if (RELATIONSHIP_TYPE_REFLEXIVE.equals(response.getType())) {
                 assertTrue(response.getReciprocal());
-                reflexiveList.add(response.getUrn());
+                assertEquals(reflexiveUrn1, response.getUrn());
             } else {
                 assertFalse(response.getReciprocal());
-                nonReflexiveList.add(response.getUrn());
+                assertEquals(nonReflexiveUrn1, response.getUrn());
             }
+
+            assertNotEquals(reflexiveUrn2, response.getUrn());
+            assertNotEquals(nonReflexiveUrn2, response.getUrn());
         }
-
-        assertFalse(reflexiveList.isEmpty());
-        assertEquals(2, reflexiveList.size());
-        assertTrue(reflexiveList.contains(reflexiveUrn1));
-        assertTrue(reflexiveList.contains(reflexiveUrn2));
-
-        assertFalse(nonReflexiveList.isEmpty());
-        assertEquals(2, nonReflexiveList.size());
-        assertTrue(nonReflexiveList.contains(nonReflexiveUrn1));
-        assertTrue(nonReflexiveList.contains(nonReflexiveUrn2));
     }
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
@@ -369,18 +369,31 @@ public class RelationshipPersistanceServiceTest {
         List<RelationshipResponse> responseList = relationshipPersistenceService.findAllReflexive(accountUrn, REFERENCE_TYPE, ENTITY_URN_A);
 
         assertFalse(responseList.isEmpty());
-        assertEquals(2, responseList.size());
-        assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(0).getType());
-        assertEquals(RELATIONSHIP_TYPE_REFLEXIVE, responseList.get(1).getType());
+        assertEquals(4, responseList.size());
+        
+        List<String> reflexiveList = new ArrayList<>();
+        List<String> nonReflexiveList = new ArrayList<>();
+        
+        for (RelationshipResponse response : responseList) {
+            
+            assertNotNull(response.getReciprocal());
+            if (RELATIONSHIP_TYPE_REFLEXIVE.equals(response.getType())) {
+                assertTrue(response.getReciprocal());
+                reflexiveList.add(response.getUrn());
+            } else {
+                assertFalse(response.getReciprocal());
+                nonReflexiveList.add(response.getUrn());
+            }
+        }
 
-        List<String> urnList = responseList.stream()
-            .map(o -> o.getUrn())
-            .collect(Collectors.toList());
+        assertFalse(reflexiveList.isEmpty());
+        assertEquals(2, reflexiveList.size());
+        assertTrue(reflexiveList.contains(reflexiveUrn1));
+        assertTrue(reflexiveList.contains(reflexiveUrn2));
 
-        assertTrue(urnList.contains(reflexiveUrn1));
-        assertTrue(urnList.contains(reflexiveUrn2));
-
-        assertFalse(urnList.contains(nonReflexiveUrn1));
-        assertFalse(urnList.contains(nonReflexiveUrn2));
+        assertFalse(nonReflexiveList.isEmpty());
+        assertEquals(2, nonReflexiveList.size());
+        assertTrue(nonReflexiveList.contains(nonReflexiveUrn1));
+        assertTrue(nonReflexiveList.contains(nonReflexiveUrn2));
     }
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistanceServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -381,5 +382,67 @@ public class RelationshipPersistanceServiceTest {
             assertNotEquals(reflexiveUrn2, response.getUrn());
             assertNotEquals(nonReflexiveUrn2, response.getUrn());
         }
+    }
+
+    @Test
+    public void testFindAllReflexive() {
+        final String ENTITY_URN_A = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+        final String ENTITY_URN_B = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+
+        final String REFERENCE_TYPE = "Thing";
+        final String RELATIONSHIP_TYPE_REFLEXIVE = "Reflexive";
+        final String RELATIONSHIP_TYPE_NON_REFLEXIVE_A = "Not Reflexive";
+        final String RELATIONSHIP_TYPE_NON_REFLEXIVE_B = "Not Reflexive as well";
+
+        RelationshipUpsert reflexiveEntity1 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_A)
+            .type(RELATIONSHIP_TYPE_REFLEXIVE)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_B)
+            .build();
+        final String reflexiveUrn1 = relationshipPersistenceService.upsert(accountUrn, reflexiveEntity1).getUrn();
+
+        RelationshipUpsert reflexiveEntity2 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_B)
+            .type(RELATIONSHIP_TYPE_REFLEXIVE)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_A)
+            .build();
+        final String reflexiveUrn2 = relationshipPersistenceService.upsert(accountUrn, reflexiveEntity2).getUrn();
+
+        RelationshipUpsert nonReflexiveEntity1 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_A)
+            .type(RELATIONSHIP_TYPE_NON_REFLEXIVE_A)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_B)
+            .build();
+        final String nonReflexiveUrn1 = relationshipPersistenceService.upsert(accountUrn, nonReflexiveEntity1).getUrn();
+
+        RelationshipUpsert nonReflexiveEntity2 = RelationshipUpsert.builder()
+            .entityReferenceType(REFERENCE_TYPE)
+            .referenceUrn(ENTITY_URN_B)
+            .type(RELATIONSHIP_TYPE_NON_REFLEXIVE_B)
+            .relatedEntityReferenceType(REFERENCE_TYPE)
+            .relatedReferenceUrn(ENTITY_URN_A)
+            .build();
+        final String nonReflexiveUrn2 = relationshipPersistenceService.upsert(accountUrn, nonReflexiveEntity2).getUrn();
+
+        List<RelationshipResponse> responseList = relationshipPersistenceService.findAllReflexive(accountUrn, REFERENCE_TYPE, ENTITY_URN_A);
+
+        assertFalse(responseList.isEmpty());
+        assertEquals(2, responseList.size());
+
+        List<String> urnList = responseList.stream()
+            .map(o -> o.getUrn())
+            .collect(Collectors.toList());
+
+        assertTrue(urnList.contains(reflexiveUrn1));
+        assertTrue(urnList.contains(reflexiveUrn2));
+
+        assertFalse(urnList.contains(nonReflexiveUrn1));
+        assertFalse(urnList.contains(nonReflexiveUrn2));
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds implementations of two different methods to look up reflexive relationships:
##### `findAll()` with `checkReciprocal` flag

`findAll()` has got a second signature that takes an additional `Boolean checkReciprocal` argument. If this flag is set to `false`, the method does the same as the other `findAll()`. Otherwise a `reciprocal` flag is set in the `RelationshipResponse` to indicate if the relationship has a reciprocal counterpart (which, however, is not included in the response list).
##### `findAllReflexive()`

`findAllReflexive()` returns all bi-directional relationships for an entity: The response includes all relationships where the specified reference entity is either the reference entity or the related reference entity where both relationships have the same type.
Thus, the returned list actually contains each relationship (type) between the entities twice:

```
                Reference    Type             Related Ref.
Relationship 1: [Entity A] --[relates to]---> [Entity B]
Relationship 2: [Entity B] --[relates to]---> [Entity A]
```
### How is this patch documented?

Code and Javadoc in the `RelationshipDao` interface.
### How was this patch tested?

Unit tests.
#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-relationships/pull/8
