### PR TITLE
Fix empty page meta information

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS Objects Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+No new features are added in this release.
+
+=== Bugfixes & Improvements
+
+* OBJECTS-979 Empty page response returns incorrect number of pages
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,4 +1,4 @@
-= SMART COSMOS Objects Release Notes
+= SMART COSMOS DAO Relationships for JPA Release Notes
 
 == UNRELEASED
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
             <dependency>
                 <groupId>net.smartcosmos</groupId>
                 <artifactId>smartcosmos-dao-relationships</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/net/smartcosmos/dao/relationships/converter/SpringDataPageToRelationshipResponsePageConverter.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/converter/SpringDataPageToRelationshipResponsePageConverter.java
@@ -28,10 +28,10 @@ public class SpringDataPageToRelationshipResponsePageConverter
     public Page<RelationshipResponse> convert(org.springframework.data.domain.Page<RelationshipEntity> page) {
 
         PageInformation pageInformation = PageInformation.builder()
-            .number(page.getNumber() + 1)
+            .number((page.getTotalElements() > 0 ? page.getNumber() + 1 : 0))
             .totalElements(page.getTotalElements())
             .size(page.getNumberOfElements())
-            .totalPages(page.getTotalPages())
+            .totalPages((page.getNumberOfElements() > 0 ? page.getTotalPages() : 0))
             .build();
 
         List<RelationshipResponse> data = page.getContent()

--- a/src/test/java/net/smartcosmos/dao/relationships/converter/SpringDataPageToRelationshipResponsePageConverterTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/converter/SpringDataPageToRelationshipResponsePageConverterTest.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.dao.relationships.converter;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.*;
@@ -10,6 +11,7 @@ import net.smartcosmos.dao.relationships.domain.RelationshipEntity;
 import net.smartcosmos.dao.relationships.util.RelationshipPersistenceUtil;
 import net.smartcosmos.dao.relationships.util.UuidUtil;
 import net.smartcosmos.dto.relationships.Page;
+import net.smartcosmos.dto.relationships.PageInformation;
 import net.smartcosmos.dto.relationships.RelationshipResponse;
 
 import static org.junit.Assert.*;
@@ -45,7 +47,6 @@ public class SpringDataPageToRelationshipResponsePageConverterTest extends Abstr
         List<RelationshipEntity> content = new ArrayList<>();
         content.add(relationshipEntity);
 
-        Page<RelationshipResponse> emptyPage = RelationshipPersistenceUtil.emptyPage();
         org.springframework.data.domain.Page<RelationshipEntity> entityPage = new PageImpl<>(content);
         Page<RelationshipResponse> convertedPage = conversionService.convert(entityPage, Page.class);
         RelationshipResponse response = convertedPage.getData()
@@ -62,6 +63,29 @@ public class SpringDataPageToRelationshipResponsePageConverterTest extends Abstr
         assertEquals(response.getTarget()
                          .getUrn(), UuidUtil.getThingUrnFromUuid(relationshipEntity.getTargetId()));
         assertEquals(response.getRelationshipType(), relationshipEntity.getRelationshipType());
+    }
+
+    @Test
+    public void thatEmptyPageConversionSucceeds() {
+
+        List<RelationshipEntity> content = new ArrayList<>();
+        org.springframework.data.domain.Page<RelationshipEntity> emptyEntityPage = new PageImpl<>(content);
+
+        Page<RelationshipResponse> convertedPage = conversionService.convert(emptyEntityPage, Page.class);
+
+        Collection<RelationshipResponse> data = convertedPage.getData();
+
+        assertTrue(data.isEmpty());
+
+        PageInformation pageInformation = convertedPage.getPage();
+
+        assertEquals(0, pageInformation.getSize());
+        assertEquals(0, pageInformation.getNumber());
+        assertEquals(0, pageInformation.getTotalPages());
+        assertEquals(0, pageInformation.getTotalElements());
+
+        Page<RelationshipResponse> emptyPage = RelationshipPersistenceUtil.emptyPage();
+        assertEquals(emptyPage, convertedPage);
     }
 
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceServiceTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.*;
  * actually called. It's a minor setback with Spring, one that just requires some diligent
  * testing.accountId
  */
-@SuppressWarnings("Duplicates")
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = {
     RelationshipPersistenceTestApplication.class,
@@ -80,7 +79,6 @@ public class RelationshipPersistenceServiceTest {
     public void testCreateSuccess() {
 
         final String TEST_SOURCE_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
-        ;
         final String TEST_TARGET_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
         final String TEST_SOURCE_TYPE = "Thing";
         final String TEST_TARGET_TYPE = "Thing";
@@ -128,7 +126,6 @@ public class RelationshipPersistenceServiceTest {
     public void testCreateReturnsEmptyOptionalOnSecondCreateOfSameRelationship() {
 
         final String TEST_SOURCE_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
-        ;
         final String TEST_TARGET_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
         final String TEST_SOURCE_TYPE = "Thing";
         final String TEST_TARGET_TYPE = "Thing";
@@ -182,7 +179,6 @@ public class RelationshipPersistenceServiceTest {
     public void testCreateThrowsIllegalArgumentExceptionOnBadSourceUrn() {
 
         final String TEST_SOURCE_URN = "nonConformingUrn:" + UuidUtil.getNewUuidAsString();
-        ;
         final String TEST_TARGET_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
         final String TEST_SOURCE_TYPE = "Thing";
         final String TEST_TARGET_TYPE = "Thing";
@@ -638,6 +634,15 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(0,
                      responsePage.getPage()
                          .getSize());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getNumber());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalElements());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalPages());
     }
 
     @Test
@@ -707,6 +712,15 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(0,
                      responsePage.getPage()
                          .getSize());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getNumber());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalElements());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalPages());
     }
 
     @Test
@@ -812,6 +826,15 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(0,
                      responsePage.getPage()
                          .getSize());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getNumber());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalElements());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalPages());
     }
 
     @Test
@@ -917,6 +940,15 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(0,
                      responsePage.getPage()
                          .getSize());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getNumber());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalElements());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalPages());
     }
 
     @Test
@@ -1022,6 +1054,15 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(0,
                      responsePage.getPage()
                          .getSize());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getNumber());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalElements());
+        assertEquals(0,
+                     responsePage.getPage()
+                         .getTotalPages());
     }
 
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the empty page response, which previously contained incorrect values for `totalPages` and `number`.

Also makes sure, that the page information aren't `null` when using the builder.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

Builder fix in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-relationships/pull/13
