### PR TITLE
include tenantUrn into source and target of responses

### DIFF
--- a/src/main/java/net/smartcosmos/dao/relationships/converter/RelationshipEntityToRelationshipResponseConverter.java
+++ b/src/main/java/net/smartcosmos/dao/relationships/converter/RelationshipEntityToRelationshipResponseConverter.java
@@ -20,11 +20,13 @@ public class RelationshipEntityToRelationshipResponseConverter
         RelationshipReference source = RelationshipReference.builder()
             .urn(UuidUtil.getThingUrnFromUuid(entity.getSourceId()))
             .type(entity.getSourceType())
+            .tenantUrn(UuidUtil.getTenantUrnFromUuid(entity.getTenantId()))
             .build();
 
         RelationshipReference target = RelationshipReference.builder()
             .urn(UuidUtil.getThingUrnFromUuid(entity.getTargetId()))
             .type(entity.getTargetType())
+            .tenantUrn(UuidUtil.getTenantUrnFromUuid(entity.getTenantId()))
             .build();
 
         return RelationshipResponse.builder()

--- a/src/test/java/net/smartcosmos/dao/relationships/converter/RelationshipEntityToRelationshipResponseConverterTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/converter/RelationshipEntityToRelationshipResponseConverterTest.java
@@ -1,5 +1,7 @@
 package net.smartcosmos.dao.relationships.converter;
 
+import java.util.UUID;
+
 import org.junit.*;
 
 import net.smartcosmos.dao.relationships.domain.RelationshipEntity;
@@ -33,6 +35,8 @@ public class RelationshipEntityToRelationshipResponseConverterTest {
     @Test
     public void testConvert() throws Exception {
 
+        final UUID TEST_TENANT_ID = UuidUtil.getNewUuid();
+        final String TEST_TENANT_URN = UuidUtil.getTenantUrnFromUuid(TEST_TENANT_ID);
         final String TEST_SOURCE_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
         final String TEST_TARGET_URN = "urn:thing:uuid:" + UuidUtil.getNewUuidAsString();
         final String TEST_SOURCE_TYPE = "Thing";
@@ -42,7 +46,7 @@ public class RelationshipEntityToRelationshipResponseConverterTest {
         RelationshipEntity relationshipEntity = RelationshipEntity
             .builder()
             .id(UuidUtil.getNewUuid())
-            .tenantId(UuidUtil.getNewUuid())
+            .tenantId(TEST_TENANT_ID)
             .sourceId(UuidUtil.getUuidFromUrn(TEST_SOURCE_URN))
             .sourceType(TEST_SOURCE_TYPE)
             .targetId(UuidUtil.getUuidFromUrn(TEST_TARGET_URN))
@@ -62,5 +66,9 @@ public class RelationshipEntityToRelationshipResponseConverterTest {
         assertEquals(UuidUtil.getUuidFromUrn(relationshipResponse.getTarget()
                                                  .getUrn()), relationshipEntity.getTargetId());
         assertEquals(relationshipResponse.getRelationshipType(), relationshipEntity.getRelationshipType());
+
+        assertEquals(TEST_TENANT_URN, relationshipResponse.getTenantUrn());
+        assertEquals(TEST_TENANT_URN, relationshipResponse.getSource().getTenantUrn());
+        assertEquals(TEST_TENANT_URN, relationshipResponse.getTarget().getTenantUrn());
     }
 }

--- a/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/relationships/impl/RelationshipPersistenceServiceTest.java
@@ -120,6 +120,17 @@ public class RelationshipPersistenceServiceTest {
                      relationshipResponse.get()
                          .getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTarget()
+                         .getTenantUrn());
     }
 
     @Test
@@ -167,6 +178,17 @@ public class RelationshipPersistenceServiceTest {
                      relationshipResponse.get()
                          .getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTarget()
+                         .getTenantUrn());
 
         Optional<RelationshipResponse> relationshipResponse2 = relationshipPersistenceService
             .create(accountUrn, relationshipCreate);
@@ -347,6 +369,17 @@ public class RelationshipPersistenceServiceTest {
                      relationshipResponse.get()
                          .getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -411,6 +444,17 @@ public class RelationshipPersistenceServiceTest {
                      relationshipResponse.get()
                          .getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     relationshipResponse.get()
+                         .getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -611,6 +655,14 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(TEST_TARGET_URN,
                      response.getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     response.getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -767,6 +819,14 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(TEST_TARGET_URN,
                      response.getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     response.getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -881,6 +941,14 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(TEST_TARGET_URN,
                      response.getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     response.getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -996,6 +1064,14 @@ public class RelationshipPersistenceServiceTest {
         assertEquals(TEST_TARGET_URN,
                      response.getTarget()
                          .getUrn());
+        assertEquals(accountUrn,
+                     response.getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getSource()
+                         .getTenantUrn());
+        assertEquals(accountUrn,
+                     response.getTarget()
+                         .getTenantUrn());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Include tenantUrn of source and target reference into the responses
### How is this patch documented?

Relationship responses now look like this:

```
{
  "urn": "urn:relationship:uuid:a4b61805-81e6-4f76-874a-e8dbbfe47479",
  "source": {
    "type": "Thing",
    "urn": "urn:thing:uuid:a903a905-6923-4ba7-8db3-b138a241c954",
    "tenantUrn": "urn:tenant:uuid:aeef431f-79fa-4599-bac3-c1890270fdfb"
  },
  "target": {
    "type": "Thing",
    "urn": "urn:thing:uuid:a903a905-6923-4ba7-8db3-b138a241c955",
    "tenantUrn": "urn:tenant:uuid:aeef431f-79fa-4599-bac3-c1890270fdfb"
  },
  "relationshipType": "Test2",
  "tenantUrn": "urn:tenant:uuid:aeef431f-79fa-4599-bac3-c1890270fdfb"
}
```

The RelationshipEntityToRelationshipResponseConverter has been updated to push the tenantUrns into the references. Also the related tests have been updated to check for presence of the tenantUrn.
#### Limitations

Currently only relationships with source and target of the same tenant are supported, unless a new
database scheme is created, which supports cross-tenant relationships.
### How was this patch tested?
- JUnit + Postman
#### Depends On

None.
After merge, rebuild smartcosmos-ext-relationships-rdao and smartcosmos-ext-relationships
